### PR TITLE
Remove filter url's from the url

### DIFF
--- a/src/Plugin/Model/AjaxNavigationResultPlugin.php
+++ b/src/Plugin/Model/AjaxNavigationResultPlugin.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Emico\AttributeLandingTweakwise\Plugin\Model;
+
+use Emico\AttributeLanding\Model\LandingPageContext;
+use Emico\AttributeLandingTweakwise\Model\FilterManager;
+use Emico\Tweakwise\Model\AjaxNavigationResult;
+use Emico\Tweakwise\Model\Catalog\Layer\Url;
+use Emico\Tweakwise\Model\Catalog\Layer\Url\UrlModel;
+use Emico\Tweakwise\Model\Catalog\Layer\Url\Strategy\PathSlugStrategy;
+use Magento\Framework\App\Request\Http as MagentoHttpRequest;
+
+class AjaxNavigationResultPlugin
+{
+    /**
+     * @var MagentoHttpRequest
+     */
+    private $request;
+
+    /**
+     * @var LandingPageContext
+     */
+    private $landingPageContext;
+
+    /**
+     * @var FilterManager
+     */
+    private $filterManager;
+
+    /**
+     * @var Url
+     */
+    private $url;
+
+    /**
+     * @var UrlModel
+     */
+    private $urlModel;
+
+    public function __construct(
+        MagentoHttpRequest $request,
+        LandingPageContext $landingPageContext,
+        FilterManager $filterManager,
+        Url $url,
+        UrlModel $urlModel
+    ) {
+        $this->request = $request;
+        $this->landingPageContext = $landingPageContext;
+        $this->filterManager = $filterManager;
+        $this->urlModel = $urlModel;
+        $this->url = $url;
+    }
+
+    public function aroundGetResponseUrl(AjaxNavigationResult $ajaxNavigationResult, callable $proceed) {
+       $type = $this->request->getParam('__tw_ajax_type');
+
+        if ($type === 'landingpage' && $this->landingPageContext->getLandingPage()) {
+            $filters = $this->filterManager->getActiveFiltersExcludingLandingPageFilters();
+            $url = $this->url->getFilterUrl($filters);
+
+            return $url;
+       }
+
+       return $proceed();
+    }
+}

--- a/src/Plugin/PathSlugStrategyPlugin.php
+++ b/src/Plugin/PathSlugStrategyPlugin.php
@@ -208,8 +208,10 @@ class PathSlugStrategyPlugin
                 $query['product_list_mode'] = $mode;
             }
 
+            $magentoUrl = $original->getMagentoUrl();
+
             return filter_var(
-                $original->magentoUrl->getDirectUrl($twOriginalUrl, ['_query' => $query]),
+                $magentoUrl->getDirectUrl($twOriginalUrl, ['_query' => $query]),
                 FILTER_SANITIZE_URL
             );
         }

--- a/src/Plugin/PathSlugStrategyPlugin.php
+++ b/src/Plugin/PathSlugStrategyPlugin.php
@@ -171,4 +171,49 @@ class PathSlugStrategyPlugin
             ltrim(implode('/', $filters), '/')
         );
     }
+
+    /**
+     * @param MagentoHttpRequest $request
+     * @return string
+     */
+    public function afterGetOriginalUrl(PathSlugStrategy $original, string $result, MagentoHttpRequest $request): string
+    {
+        $landingPage = $this->landingPageContext->getLandingPage();
+        if ($landingPage === null) {
+            return $result;
+        }
+
+        if ($twOriginalUrl = $request->getParam('__tw_original_url')) {
+            // This seems ugly, perhaps there is another way?
+            $query = [];
+            // Add page and sort
+            $page = $request->getParam('p');
+            $sort = $request->getParam('product_list_order');
+            $limit = $request->getParam('product_list_limit');
+            $mode = $request->getParam('product_list_mode');
+
+            if ($page &&
+                (int) $page > 1
+            ) {
+                $query['p'] = $page;
+            }
+
+            if ($sort) {
+                $query['product_list_order'] = $sort;
+            }
+            if ($limit) {
+                $query['product_list_limit'] = $limit;
+            }
+            if ($mode) {
+                $query['product_list_mode'] = $mode;
+            }
+
+            return filter_var(
+                $original->magentoUrl->getDirectUrl($twOriginalUrl, ['_query' => $query]),
+                FILTER_SANITIZE_URL
+            );
+        }
+
+        return $result;
+    }
 }

--- a/src/Plugin/QueryParameterStrategyPlugin.php
+++ b/src/Plugin/QueryParameterStrategyPlugin.php
@@ -8,7 +8,11 @@ namespace Emico\AttributeLandingTweakwise\Plugin;
 
 use Emico\AttributeLanding\Model\LandingPageContext;
 use Emico\AttributeLandingTweakwise\Model\FilterManager;
+use Emico\Tweakwise\Model\Catalog\Layer\Filter\Item;
 use Emico\Tweakwise\Model\Catalog\Layer\Url\Strategy\QueryParameterStrategy;
+use Emico\Tweakwise\Model\Catalog\Layer\Url\UrlModel;
+use Emico\Tweakwise\Model\Client\Type\FacetType\SettingsType;
+use Magento\Framework\App\Request\Http as MagentoHttpRequest;
 use Magento\Framework\Url;
 
 class QueryParameterStrategyPlugin
@@ -28,14 +32,21 @@ class QueryParameterStrategyPlugin
      */
     private $magentoUrl;
 
+    /**
+     * @var UrlModel
+     */
+    private $url;
+
     public function __construct(
         LandingPageContext $landingPageContext,
         FilterManager $filterManager,
-        Url $magentoUrl
+        Url $magentoUrl,
+        UrlModel $url
     ) {
         $this->landingPageContext = $landingPageContext;
         $this->filterManager = $filterManager;
         $this->magentoUrl = $magentoUrl;
+        $this->url = $url;
     }
 
     /**
@@ -82,5 +93,31 @@ class QueryParameterStrategyPlugin
             ltrim($urlParts['path'], '/'),
             ['_query' => $query]
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function afterGetAttributeFilters(QueryParameterStrategy $original, array $result, MagentoHttpRequest $request)
+    {
+        $landingPage = $this->landingPageContext->getLandingPage();
+        if ($landingPage === null) {
+            return $result;
+        }
+
+        $filters = $landingPage->getFilters();
+
+        //hide landingspage filters in url
+        foreach ($filters as $filter) {
+            if (isset($result[$filter->getFacet()])) {
+                foreach ($result[$filter->getFacet()] as $key => $value) {
+                    if ($value == $filter->getValue()) {
+                        unset ($result[$filter->getFacet()][$key]);
+                    }
+                }
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -33,6 +33,10 @@
         <plugin name="AttributeLandingTweakwise" type="Emico\AttributeLandingTweakwise\Plugin\UrlPlugin" />
     </type>
 
+    <type name="Emico\Tweakwise\Model\AjaxNavigationResult">
+        <plugin name="AttributeLandingTweakwise" type="Emico\AttributeLandingTweakwise\Plugin\Model\AjaxNavigationResultPlugin" />
+    </type>
+
     <type name="Emico\Tweakwise\Model\Catalog\Layer\Url\Strategy\PathSlugStrategy">
         <plugin name="AttributeLandingTweakwise" type="Emico\AttributeLandingTweakwise\Plugin\PathSlugStrategyPlugin" />
         <arguments>


### PR DESCRIPTION
Screencast
https://watch.screencastify.com/v/9uUP7Dk1tfDadF0ZUjYy

When ajax is enabled, you get double filtering in the URL with an attirbute landing page. 

Happy flow; without AJAX filtering 

Go to an ALP /tables. An ALP based on round tables. There is no filter shape/round in the url (url is /tables)

Non happy flow; with AJAX filtering
Go to an ALP /tables. An ALP based on an filter round tables. In the url you get /tables/shape/round. This should be the same url as above.

Note, this pull request requires an change in the tweakwise module for the fix to work. I'll link the pull request
